### PR TITLE
Remove dependency with the core

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ It is done automatically by the LwIP stack in a background task.
 An Idle task is required by the LwIP stack to handle timer and data reception.
 This idle task is called inside the main loop in background by the function
 stm32_eth_scheduler(). Be careful to not lock the system inside the function
-loop() where LwIP could never be updated. Call EthernetUDP::parsePacket() or
-EthernetClient::available() performs an update of the LwIP stack.
+loop() where LwIP could never be updated. Call Ethernet::schedule() performs an
+update of the LwIP stack.
 
 ## Wiki
 

--- a/src/STM32Ethernet.cpp
+++ b/src/STM32Ethernet.cpp
@@ -73,6 +73,15 @@ int EthernetClass::maintain(){
   return rc;
 }
 
+/*
+ * This function updates the LwIP stack and can be called to be sure to update
+ * the stack (e.g. in case of a long loop).
+ */
+void EthernetClass::schedule(void)
+{
+  stm32_eth_scheduler();
+}
+
 IPAddress EthernetClass::localIP()
 {
   return IPAddress(stm32_eth_get_ipaddr());

--- a/src/STM32Ethernet.h
+++ b/src/STM32Ethernet.h
@@ -21,6 +21,7 @@ public:
   void begin(uint8_t *mac_address, IPAddress local_ip, IPAddress dns_server, IPAddress gateway);
   void begin(uint8_t *mac_address, IPAddress local_ip, IPAddress dns_server, IPAddress gateway, IPAddress subnet);
   int maintain();
+  void schedule(void);
 
   IPAddress localIP();
   IPAddress subnetMask();

--- a/src/utility/stm32_eth.c
+++ b/src/utility/stm32_eth.c
@@ -46,6 +46,15 @@
 #include "lwip/prot/dhcp.h"
 #include "lwip/dns.h"
 
+//Keeps compatibilty with older version of the STM32 core
+#if __has_include("core_callback.h")
+#include "core_callback.h"
+#else
+void registerCoreCallback(void (*func)(void)) {
+  UNUSED(func);
+}
+#endif
+
 
 #ifdef __cplusplus
  extern "C" {
@@ -168,6 +177,9 @@ void stm32_eth_init(const uint8_t *mac, const uint8_t *ip, const uint8_t *gw, co
   User_notification(&gnetif);
 
   stm32_eth_scheduler();
+
+  // stm32_eth_scheduler() will be called directly inside the loop of the main() function.
+  registerCoreCallback(stm32_eth_scheduler);
 }
 
 /**


### PR DESCRIPTION
I added an update function to the Ethernet class to remove the dependency inside the main.cpp.
The library is now completely independent of the core.
The function update() updates the LwIP stack also.