### PR TITLE
Fix issue #3 and #4

### DIFF
--- a/src/EthernetClient.cpp
+++ b/src/EthernetClient.cpp
@@ -158,15 +158,10 @@ void EthernetClient::stop() {
     return;
   }
 
-  // Close tcp connection. If failed, force to close connection.
-  if(ERR_OK != tcp_close(_tcp_client->pcb)) {
-    tcp_abort(_tcp_client->pcb);
+  // close tcp connection if not closed yet
+  if(status() != TCP_CLOSING) {
+    tcp_connection_close(_tcp_client->pcb, _tcp_client);
   }
-
-  _tcp_client->pcb = NULL;
-
-   mem_free(_tcp_client);
-  _tcp_client = NULL;
 }
 
 uint8_t EthernetClient::connected() {

--- a/src/utility/stm32_eth.h
+++ b/src/utility/stm32_eth.h
@@ -167,6 +167,7 @@ uint32_t ip_addr_to_u32(ip_addr_t *ipaddr);
 #if LWIP_TCP
 err_t tcp_connected_callback(void *arg, struct tcp_pcb *tpcb, err_t err);
 err_t tcp_accept_callback(void *arg, struct tcp_pcb *newpcb, err_t err);
+void tcp_connection_close(struct tcp_pcb *tpcb, struct tcp_struct *tcp);
 #else
 #error "LWIP_TCP must be enabled in lwipopts.h"
 #endif


### PR DESCRIPTION
This PR should fix #3 
- Ethernet scheduler called by timer every 1ms
- function close client reworked

To test this PR please add `#define DEFAULT_ETHERNET_TIMER TIM6` in lwipopts.h

The issue #4 is also fixed:
- init sequence is done only once even if `begin()` is called several time.