### PR TITLE
Default lwipopts.h to avoid embed it in the core and allow easiest user config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
-# STM32Ethernet
-
-## Ethernet Library for Arduino
+# STM32 Ethernet Library for Arduino
 
 With an STM32 board with Ethernet compatibility, this library allows a STM32
 board (NUCLEO, DISCOVERY, ...) to connect to the internet.  
@@ -8,14 +6,25 @@ board (NUCLEO, DISCOVERY, ...) to connect to the internet.
 This library follows the Ethernet API from Arduino.<br>
 For more information about it please visit: http://www.arduino.cc/en/Reference/Ethernet
 
-## Note
+## Dependency
 
-The library is based on LwIP, a Lightweight TCP/IP stack, available here:
+This library is based on LwIP, a Lightweight TCP/IP stack, available here:
 
 http://git.savannah.gnu.org/cgit/lwip.git
 
-The LwIP has been ported as Arduino library. The STM32Ethernet library depends
-on it.
+The LwIP has been ported as Arduino library and is available thanks Arduino Library Manager.
+
+Source: https://github.com/stm32duino/LwIP
+
+## Configuration
+
+The LwIP has several user defined options, which is specified from within the `lwipopts.h` file.
+
+This library provides a default user defined options file named `lwipopts_default.h`.
+
+User can provide his own defined options at sketch level by adding his configuration in a file named `STM32lwipopts.h`.
+
+## Note
 
 `EthernetClass::maintain()` in no more required to renew IP address from DHCP.<br>
 It is done automatically by the LwIP stack in a background task.  

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=STM32duino STM32Ethernet
-version=1.0.2
+version=1.0.3
 author=Various
 maintainer=STMicroelectronics
 sentence=Enables network connection (local and Internet) using the STM32 Board.

--- a/src/lwipopts.h
+++ b/src/lwipopts.h
@@ -1,0 +1,18 @@
+/*
+ * @file    lwipopts.h
+ * @author  Frederic Pillon <frederic.pillon@st.com> for STMicroelectronics.
+ * @brief   Include header file to match Arduino library format
+ */
+
+#ifndef _ARDUINO_LWIPOPTS_H
+#define _ARDUINO_LWIPOPTS_H
+
+/* LwIP specific configuration options. */
+#if __has_include("STM32lwipopts.h")
+#include "STM32lwipopts.h"
+#else
+#include "lwipopts_default.h"
+#endif
+
+#endif /* _ARDUINO_LWIPOPTS_H */
+

--- a/src/lwipopts_default.h
+++ b/src/lwipopts_default.h
@@ -1,0 +1,249 @@
+/**
+  ******************************************************************************
+  * @file    lwipopts_default.h
+  * @author  MCD Application Team
+  * @brief   lwIP Options Configuration.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; Copyright (c) 2017 STMicroelectronics International N.V.
+  * All rights reserved.</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without
+  * modification, are permitted, provided that the following conditions are met:
+  *
+  * 1. Redistribution of source code must retain the above copyright notice,
+  *    this list of conditions and the following disclaimer.
+  * 2. Redistributions in binary form must reproduce the above copyright notice,
+  *    this list of conditions and the following disclaimer in the documentation
+  *    and/or other materials provided with the distribution.
+  * 3. Neither the name of STMicroelectronics nor the names of other
+  *    contributors to this software may be used to endorse or promote products
+  *    derived from this software without specific written permission.
+  * 4. This software, including modifications and/or derivative works of this
+  *    software, must execute solely and exclusively on microcontroller or
+  *    microprocessor devices manufactured by or for STMicroelectronics.
+  * 5. Redistribution and use of this software other than as permitted under
+  *    this license is void and will automatically terminate your rights under
+  *    this license.
+  *
+  * THIS SOFTWARE IS PROVIDED BY STMICROELECTRONICS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS, IMPLIED OR STATUTORY WARRANTIES, INCLUDING, BUT NOT
+  * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+  * PARTICULAR PURPOSE AND NON-INFRINGEMENT OF THIRD PARTY INTELLECTUAL PROPERTY
+  * RIGHTS ARE DISCLAIMED TO THE FULLEST EXTENT PERMITTED BY LAW. IN NO EVENT
+  * SHALL STMICROELECTRONICS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+  * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+  * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+  * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+  * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+  * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+#ifndef __LWIPOPTS_H__
+#define __LWIPOPTS_H__
+
+/**
+ * NO_SYS==1: Provides VERY minimal functionality. Otherwise,
+ * use lwIP facilities.
+ */
+#define NO_SYS                  1
+
+/**
+ * SYS_LIGHTWEIGHT_PROT==1: if you want inter-task protection for certain
+ * critical regions during buffer allocation, deallocation and memory
+ * allocation and deallocation.
+ */
+#define SYS_LIGHTWEIGHT_PROT    0
+
+/* ---------- Memory options ---------- */
+/* MEM_ALIGNMENT: should be set to the alignment of the CPU for which
+   lwIP is compiled. 4 byte alignment -> define MEM_ALIGNMENT to 4, 2
+   byte alignment -> define MEM_ALIGNMENT to 2. */
+#define MEM_ALIGNMENT           4
+
+/* MEM_SIZE: the size of the heap memory. If the application will send
+a lot of data that needs to be copied, this should be set high. */
+#define MEM_SIZE                (10*1024)
+
+/* MEMP_NUM_PBUF: the number of memp struct pbufs. If the application
+   sends a lot of data out of ROM (or other static memory), this
+   should be set high. */
+#define MEMP_NUM_PBUF           10
+/* MEMP_NUM_UDP_PCB: the number of UDP protocol control blocks. One
+   per active UDP "connection". */
+#define MEMP_NUM_UDP_PCB        6
+/* MEMP_NUM_TCP_PCB: the number of simulatenously active TCP
+   connections. */
+#define MEMP_NUM_TCP_PCB        10
+/* MEMP_NUM_TCP_PCB_LISTEN: the number of listening TCP
+   connections. */
+#define MEMP_NUM_TCP_PCB_LISTEN 6
+/* MEMP_NUM_TCP_SEG: the number of simultaneously queued TCP
+   segments. */
+#define MEMP_NUM_TCP_SEG        8
+/* MEMP_NUM_SYS_TIMEOUT: the number of simulateously active
+   timeouts. */
+#define MEMP_NUM_SYS_TIMEOUT    10
+
+
+/* ---------- Pbuf options ---------- */
+/* PBUF_POOL_SIZE: the number of buffers in the pbuf pool. */
+#define PBUF_POOL_SIZE          8
+
+/* PBUF_POOL_BUFSIZE: the size of each pbuf in the pbuf pool. */
+#define PBUF_POOL_BUFSIZE       1524
+
+
+/* ---------- TCP options ---------- */
+#define LWIP_TCP                1
+#define TCP_TTL                 255
+
+/* Controls if TCP should queue segments that arrive out of
+   order. Define to 0 if your device is low on memory. */
+#define TCP_QUEUE_OOSEQ         0
+
+/* TCP Maximum segment size. */
+#define TCP_MSS                 (1500 - 40)	  /* TCP_MSS = (Ethernet MTU - IP header size - TCP header size) */
+
+/* TCP sender buffer space (bytes). */
+#define TCP_SND_BUF             (4*TCP_MSS)
+
+/*  TCP_SND_QUEUELEN: TCP sender buffer space (pbufs). This must be at least
+  as much as (2 * TCP_SND_BUF/TCP_MSS) for things to work. */
+
+#define TCP_SND_QUEUELEN        (2* TCP_SND_BUF/TCP_MSS)
+
+/* TCP receive window. */
+#define TCP_WND                 (2*TCP_MSS)
+
+
+/* ---------- ICMP options ---------- */
+#define LWIP_ICMP                       1
+
+
+/* ---------- DHCP options ---------- */
+#define LWIP_DHCP               1
+
+/* ---------- DNS options ---------- */
+#define LWIP_DNS              1
+
+
+/* ---------- UDP options ---------- */
+#define LWIP_UDP                1
+#define UDP_TTL                 255
+
+
+/* ---------- Statistics options ---------- */
+#define LWIP_STATS 0
+
+/* ---------- link callback options ---------- */
+/* LWIP_NETIF_LINK_CALLBACK==1: Support a callback function from an interface
+ * whenever the link changes (i.e., link down)
+ */
+#define LWIP_NETIF_LINK_CALLBACK        1
+
+/*
+   --------------------------------------
+   ---------- Checksum options ----------
+   --------------------------------------
+*/
+
+/*
+The STM32F4x7 allows computing and verifying the IP, UDP, TCP and ICMP checksums by hardware:
+ - To use this feature let the following define uncommented.
+ - To disable it and process by CPU comment the  the checksum.
+*/
+#define CHECKSUM_BY_HARDWARE
+
+
+#ifdef CHECKSUM_BY_HARDWARE
+  /* CHECKSUM_GEN_IP==0: Generate checksums by hardware for outgoing IP packets.*/
+  #define CHECKSUM_GEN_IP                 0
+  /* CHECKSUM_GEN_UDP==0: Generate checksums by hardware for outgoing UDP packets.*/
+  #define CHECKSUM_GEN_UDP                0
+  /* CHECKSUM_GEN_TCP==0: Generate checksums by hardware for outgoing TCP packets.*/
+  #define CHECKSUM_GEN_TCP                0
+  /* CHECKSUM_CHECK_IP==0: Check checksums by hardware for incoming IP packets.*/
+  #define CHECKSUM_CHECK_IP               0
+  /* CHECKSUM_CHECK_UDP==0: Check checksums by hardware for incoming UDP packets.*/
+  #define CHECKSUM_CHECK_UDP              0
+  /* CHECKSUM_CHECK_TCP==0: Check checksums by hardware for incoming TCP packets.*/
+  #define CHECKSUM_CHECK_TCP              0
+  /* CHECKSUM_CHECK_ICMP==0: Check checksums by hardware for incoming ICMP packets.*/
+  #define CHECKSUM_GEN_ICMP               0
+#else
+  /* CHECKSUM_GEN_IP==1: Generate checksums in software for outgoing IP packets.*/
+  #define CHECKSUM_GEN_IP                 1
+  /* CHECKSUM_GEN_UDP==1: Generate checksums in software for outgoing UDP packets.*/
+  #define CHECKSUM_GEN_UDP                1
+  /* CHECKSUM_GEN_TCP==1: Generate checksums in software for outgoing TCP packets.*/
+  #define CHECKSUM_GEN_TCP                1
+  /* CHECKSUM_CHECK_IP==1: Check checksums in software for incoming IP packets.*/
+  #define CHECKSUM_CHECK_IP               1
+  /* CHECKSUM_CHECK_UDP==1: Check checksums in software for incoming UDP packets.*/
+  #define CHECKSUM_CHECK_UDP              1
+  /* CHECKSUM_CHECK_TCP==1: Check checksums in software for incoming TCP packets.*/
+  #define CHECKSUM_CHECK_TCP              1
+  /* CHECKSUM_CHECK_ICMP==1: Check checksums by hardware for incoming ICMP packets.*/
+  #define CHECKSUM_GEN_ICMP               1
+#endif
+
+
+/*
+   ----------------------------------------------
+   ---------- Sequential layer options ----------
+   ----------------------------------------------
+*/
+/**
+ * LWIP_NETCONN==1: Enable Netconn API (require to use api_lib.c)
+ */
+#define LWIP_NETCONN                    0
+
+/*
+   ------------------------------------
+   ---------- Socket options ----------
+   ------------------------------------
+*/
+/**
+ * LWIP_SOCKET==1: Enable Socket API (require to use sockets.c)
+ */
+#define LWIP_SOCKET                     0
+
+/*
+   ------------------------------------
+   ---------- httpd options ----------
+   ------------------------------------
+*/
+
+/** Set this to 1 to support CGI */
+#define LWIP_HTTPD_CGI            1
+
+/** Set this to 1 to support SSI (Server-Side-Includes) */
+#define LWIP_HTTPD_SSI            1
+
+/** Set this to 1 to include "fsdata_custom.c" instead of "fsdata.c" for the
+ * file system (to prevent changing the file included in CVS) */
+#define HTTPD_USE_CUSTOM_FSDATA   1
+
+/*
+   ------------------------------------
+   ---------- Custom options ----------
+   ------------------------------------
+*/
+
+/** Enables the Ethernet peripheral in RMII mode. If not defined, MII mode will
+    be enabled. Pin mapping must be configured for the selected mode
+    (see PinMap_Ethernet in PeripheralPins.c). */
+#define ETHERNET_RMII_MODE_CONFIGURATION 1
+
+/** Uncomment this line to use the ethernet input in interrupt mode.
+  * NOTE: LwIP stack documentation recommends to use the polling mode without
+  * an operating system. */
+//#define ETH_INPUT_USE_IT 1
+
+#endif /* __LWIPOPTS_H__ */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/


### PR DESCRIPTION
The LwIP has several user defined options, which is specified from within the `lwipopts.h` file.

Provide a default user defined options file named `lwipopts_default.h`.

User can provide his own defined options at sketch level by adding his configuration in a file named `STM32lwipopts.h`.