### PR TITLE
MAC support

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -31,6 +31,7 @@ Paul Stoffregen    https://github.com/PaulStoffregen
 per1234            https://github.com/per1234
 Richard Sim
 Scott Fitzgerald   https://github.com/shfitz
+Stefan Staub       https://github.com/sstaub
 STMicroelectronics https://github.com/stm32duino
 Thibaut Viard      https://github.com/aethaniel
 Tom Igoe           https://github.com/tigoe

--- a/README.md
+++ b/README.md
@@ -25,13 +25,29 @@ This library provides a default user defined options file named `lwipopts_defaul
 User can provide his own defined options at sketch level by adding his configuration in a file named `STM32lwipopts.h`.
 
 
-## New init procedure **!!!**
+## New alternative init procedure **!!!**
 
-The init of the Ethernetinterface changed, the ordner is now:
+There are alternative inits of the Ethernetinterface with following orders:
 
+	Ethernet.begin();
+	Ethernet.begin(ip);
+	Ethernet.begin(ip, subnet);
+	Ethernet.begin(ip, subnet, gateway);
 	Ethernet.begin(ip, subnet, gateway, dns);
 
-This is more logical. A MAC address is no more needed!
+This is more logical. A MAC address is no more needed and will retrieved internally by the mbed MAC address!
+
+You can get the MAC address with following function, this must done after Ethernet.Begin()
+	
+	uint8_t *mac;
+	Ethernet.begin();
+	mac = Ethernet.macAddress();
+
+You can also set a new user based MAC address, this must done before Ethernet.begin()
+
+	uint8_t newMAC[] = {0x00, 0x80, 0xE1, 0x01, 0x01, 0x01};
+	Ethernet.macAddress(newMAC);
+	Ethernet.begin();
 
 ## Note
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,15 @@ This library provides a default user defined options file named `lwipopts_defaul
 
 User can provide his own defined options at sketch level by adding his configuration in a file named `STM32lwipopts.h`.
 
+
+## New init procedure **!!!**
+
+The init of the Ethernetinterface changed, the ordner is now:
+
+	Ethernet.begin(ip, subnet, gateway, dns);
+
+This is more logical. A MAC address is no more needed!
+
 ## Note
 
 `EthernetClass::maintain()` in no more required to renew IP address from DHCP.<br>

--- a/examples/AdvancedChatServer/AdvancedChatServer.ino
+++ b/examples/AdvancedChatServer/AdvancedChatServer.ino
@@ -42,7 +42,7 @@ EthernetClient clients[4];
 
 void setup() {
   // initialize the Ethernet device
-  Ethernet.begin(ip, myDns, gateway, subnet);
+  Ethernet.begin(ip, subnet, gateway, myDns);
   // start listening for clients
   server.begin();
   // Open serial communications and wait for port to open:

--- a/examples/AdvancedChatServer/AdvancedChatServer.ino
+++ b/examples/AdvancedChatServer/AdvancedChatServer.ino
@@ -17,18 +17,18 @@
  by Norbert Truchsess
  modified 23 Jun 2017
  by Wi6Labs
+ modified 1 Jun 2018
+ by sstaub
 
  */
 
 #include <LwIP.h>
 #include <STM32Ethernet.h>
 
-// Enter a MAC address and IP address for your controller below.
+// Enter an IP address for your controller below.
 // The IP address will be dependent on your local network.
 // gateway and subnet are optional:
-byte mac[] = {
-  0xDE, 0xAD, 0xBE, 0xEF, 0xFE, 0xED
-};
+
 IPAddress ip(192, 168, 1, 177);
 IPAddress myDns(192, 168, 1, 1);
 IPAddress gateway(192, 168, 1, 1);
@@ -42,7 +42,7 @@ EthernetClient clients[4];
 
 void setup() {
   // initialize the Ethernet device
-  Ethernet.begin(mac, ip, myDns, gateway, subnet);
+  Ethernet.begin(ip, myDns, gateway, subnet);
   // start listening for clients
   server.begin();
   // Open serial communications and wait for port to open:

--- a/examples/BarometricPressureWebServer/BarometricPressureWebServer.ino
+++ b/examples/BarometricPressureWebServer/BarometricPressureWebServer.ino
@@ -20,6 +20,8 @@
  by Tom Igoe
  modified 23 Jun 2017
  by Wi6Labs
+ modified 1 Jun 2018
+ by sstaub
  */
 
 #include <LwIP.h>
@@ -28,11 +30,6 @@
 #include <SPI.h>
 
 
-// assign a MAC address for the Ethernet controller.
-// fill in your address here:
-byte mac[] = {
-  0xDE, 0xAD, 0xBE, 0xEF, 0xFE, 0xED
-};
 // assign an IP address for the controller:
 IPAddress ip(192, 168, 1, 20);
 
@@ -62,7 +59,7 @@ void setup() {
   SPI.begin();
 
   // start the Ethernet connection and the server:
-  Ethernet.begin(mac, ip);
+  Ethernet.begin(ip);
   server.begin();
 
   // initalize the  data ready and chip select pins:

--- a/examples/ChatServer/ChatServer.ino
+++ b/examples/ChatServer/ChatServer.ino
@@ -37,7 +37,7 @@ boolean alreadyConnected = false; // whether or not the client was connected pre
 
 void setup() {
   // initialize the ethernet device
-  Ethernet.begin(ip, myDns, gateway, subnet);
+  Ethernet.begin(ip, subnet, gateway, myDns);
   // start listening for clients
   server.begin();
   // Open serial communications and wait for port to open:

--- a/examples/ChatServer/ChatServer.ino
+++ b/examples/ChatServer/ChatServer.ino
@@ -14,17 +14,17 @@
  by Tom Igoe
  modified 23 Jun 2017
  by Wi6Labs
+ modified 1 Jun 2018
+ by sstaub
  */
 
 #include <LwIP.h>
 #include <STM32Ethernet.h>
 
-// Enter a MAC address and IP address for your controller below.
+// Enter an IP address for your controller below.
 // The IP address will be dependent on your local network.
 // gateway and subnet are optional:
-byte mac[] = {
-  0xDE, 0xAD, 0xBE, 0xEF, 0xFE, 0xED
-};
+
 IPAddress ip(192, 168, 1, 177);
 IPAddress myDns(192,168,1, 1);
 IPAddress gateway(192, 168, 1, 1);
@@ -37,7 +37,7 @@ boolean alreadyConnected = false; // whether or not the client was connected pre
 
 void setup() {
   // initialize the ethernet device
-  Ethernet.begin(mac, ip, myDns, gateway, subnet);
+  Ethernet.begin(ip, myDns, gateway, subnet);
   // start listening for clients
   server.begin();
   // Open serial communications and wait for port to open:

--- a/examples/DhcpAddressPrinter/DhcpAddressPrinter.ino
+++ b/examples/DhcpAddressPrinter/DhcpAddressPrinter.ino
@@ -14,15 +14,13 @@
   by Arturo Guadalupi
   modified 23 Jun 2017
   by Wi6Labs
+  modified 1 Jun 2018
+  by sstaub
 */
 
 #include <LwIP.h>
 #include <STM32Ethernet.h>
 
-// Enter a MAC address for your controller below.
-byte mac[] = {
-  0xDE, 0xAD, 0xBE, 0xEF, 0xFE, 0xED
-};
 
 // Initialize the Ethernet client library
 // with the IP address and port of the server
@@ -38,7 +36,7 @@ void setup() {
   }
 
   // start the Ethernet connection:
-  if (Ethernet.begin(mac) == 0) {
+  if (Ethernet.begin() == 0) {
     Serial.println("Failed to configure Ethernet using DHCP");
     // no point in carrying on, so do nothing forevermore:
     for (;;)

--- a/examples/DhcpChatServer/DhcpChatServer.ino
+++ b/examples/DhcpChatServer/DhcpChatServer.ino
@@ -51,7 +51,7 @@ void setup() {
   if (Ethernet.begin() == 0) {
     Serial.println("Failed to configure Ethernet using DHCP");
     // initialize the Ethernet device not using DHCP:
-    Ethernet.begin(ip, myDns, gateway, subnet);
+    Ethernet.begin(ip, subnet, gateway, myDns);
   }
   // print your local IP address:
   Serial.print("My IP address: ");

--- a/examples/DhcpChatServer/DhcpChatServer.ino
+++ b/examples/DhcpChatServer/DhcpChatServer.ino
@@ -18,18 +18,16 @@
  Based on ChatServer example by David A. Mellis
  modified 23 Jun 2017
  by Wi6Labs
-
+ modified 1 Jun 2018
+ by sstaub
  */
 
 #include <LwIP.h>
 #include <STM32Ethernet.h>
 
-// Enter a MAC address and IP address for your controller below.
+// Enter an IP address for your controller below.
 // The IP address will be dependent on your local network.
 // gateway and subnet are optional:
-byte mac[] = {
-  0xDE, 0xAD, 0xBE, 0xEF, 0xFE, 0xED
-};
 IPAddress ip(192, 168, 1, 177);
 IPAddress myDns(192,168,1, 1);
 IPAddress gateway(192, 168, 1, 1);
@@ -50,10 +48,10 @@ void setup() {
 
   // start the Ethernet connection:
   Serial.println("Trying to get an IP address using DHCP");
-  if (Ethernet.begin(mac) == 0) {
+  if (Ethernet.begin() == 0) {
     Serial.println("Failed to configure Ethernet using DHCP");
     // initialize the Ethernet device not using DHCP:
-    Ethernet.begin(mac, ip, myDns, gateway, subnet);
+    Ethernet.begin(ip, myDns, gateway, subnet);
   }
   // print your local IP address:
   Serial.print("My IP address: ");

--- a/examples/TelnetClient/TelnetClient.ino
+++ b/examples/TelnetClient/TelnetClient.ino
@@ -17,17 +17,15 @@
  by Tom Igoe
  modified 23 Jun 2017
  by Wi6Labs
-
+ modified 1 Jun 2018
+ by sstaub
  */
 
 #include <LwIP.h>
 #include <STM32Ethernet.h>
 
-// Enter a MAC address and IP address for your controller below.
+// Enter an IP address for your controller below.
 // The IP address will be dependent on your local network:
-byte mac[] = {
-  0xDE, 0xAD, 0xBE, 0xEF, 0xFE, 0xED
-};
 IPAddress ip(192, 168, 1, 177);
 
 // Enter the IP address of the server you're connecting to:
@@ -41,7 +39,7 @@ EthernetClient client;
 
 void setup() {
   // start the Ethernet connection:
-  Ethernet.begin(mac, ip);
+  Ethernet.begin(ip);
   // Open serial communications and wait for port to open:
   Serial.begin(9600);
   while (!Serial) {

--- a/examples/UDPSendReceiveString/UDPSendReceiveString.ino
+++ b/examples/UDPSendReceiveString/UDPSendReceiveString.ino
@@ -10,7 +10,8 @@
  by Michael Margolis
  modified 23 Jun 2017
  by Wi6Labs
-
+ modified 1 Jun 2018
+ by sstaub
  This code is in the public domain.
  */
 
@@ -19,11 +20,8 @@
 #include <EthernetUdp.h>         // UDP library from: bjoern@cs.stanford.edu 12/30/2008
 
 
-// Enter a MAC address and IP address for your controller below.
+// Enter an IP address for your controller below.
 // The IP address will be dependent on your local network:
-byte mac[] = {
-  0xDE, 0xAD, 0xBE, 0xEF, 0xFE, 0xED
-};
 IPAddress ip(192, 168, 1, 177);
 
 unsigned int localPort = 8888;      // local port to listen on
@@ -37,7 +35,7 @@ EthernetUDP Udp;
 
 void setup() {
   // start the Ethernet and UDP:
-  Ethernet.begin(mac, ip);
+  Ethernet.begin(ip);
   Udp.begin(localPort);
 
   Serial.begin(9600);

--- a/examples/UdpNtpClient/UdpNtpClient.ino
+++ b/examples/UdpNtpClient/UdpNtpClient.ino
@@ -15,7 +15,8 @@
  by Arturo Guadalupi
  modified 23 Jun 2017
  by Wi6Labs
-
+ modified 1 Jun 2018
+ by sstaub
  This code is in the public domain.
 
  */
@@ -23,11 +24,6 @@
 #include <LwIP.h>
 #include <STM32Ethernet.h>
 #include <EthernetUdp.h>
-
-// Enter a MAC address for your controller below.
-byte mac[] = {
-  0xDE, 0xAD, 0xBE, 0xEF, 0xFE, 0xED
-};
 
 unsigned int localPort = 8888;       // local port to listen for UDP packets
 
@@ -49,7 +45,7 @@ void setup() {
 
 
   // start Ethernet and UDP
-  if (Ethernet.begin(mac) == 0) {
+  if (Ethernet.begin() == 0) {
     Serial.println("Failed to configure Ethernet using DHCP");
     // no point in carrying on, so do nothing forevermore:
     for (;;)

--- a/examples/WebClient/WebClient.ino
+++ b/examples/WebClient/WebClient.ino
@@ -12,14 +12,13 @@
  by Tom Igoe, based on work by Adrian McEwen
  modified 23 Jun 2017
  by Wi6Labs
-
+ modified 1 Jun 2018
+ by sstaub
  */
 
 #include <LwIP.h>
 #include <STM32Ethernet.h>
 
-// Enter a MAC address for your controller below.
-byte mac[] = { 0xDE, 0xAD, 0xBE, 0xEF, 0xFE, 0xED };
 // if you don't want to use DNS (and reduce your sketch size)
 // use the numeric IP instead of the name for the server:
 //IPAddress server(74,125,232,128);  // numeric IP for Google (no DNS)
@@ -41,10 +40,10 @@ void setup() {
   }
 
   // start the Ethernet connection:
-  if (Ethernet.begin(mac) == 0) {
+  if (Ethernet.begin() == 0) {
     Serial.println("Failed to configure Ethernet using DHCP");
     // try to congifure using IP address instead of DHCP:
-    Ethernet.begin(mac, ip);
+    Ethernet.begin(ip);
   }
   // give the Ethernet shield a second to initialize:
   delay(1000);

--- a/examples/WebClientRepeating/WebClientRepeating.ino
+++ b/examples/WebClientRepeating/WebClientRepeating.ino
@@ -28,7 +28,8 @@
 // fill in an available IP address on your network here,
 // for manual configuration:
 IPAddress ip(192, 168, 1, 177);
-
+IPAddress gateway(192, 168, 1, 1);
+IPAddress subnet(255, 255, 0, 0);
 // fill in your Domain Name Server address here:
 IPAddress myDns(1, 1, 1, 1);
 
@@ -52,7 +53,7 @@ void setup() {
   // give the ethernet module time to boot up:
   delay(1000);
   // start the Ethernet connection using a fixed IP address and DNS server:
-  Ethernet.begin(ip, myDns);
+  Ethernet.begin(ip, subnet, gateway, myDns);
   // print the Ethernet board/shield's IP address:
   Serial.print("My IP address: ");
   Serial.println(Ethernet.localIP());

--- a/examples/WebClientRepeating/WebClientRepeating.ino
+++ b/examples/WebClientRepeating/WebClientRepeating.ino
@@ -15,7 +15,8 @@
  by Federico Vanzati
  modified 23 Jun 2017
  by Wi6Labs
-
+ modified 1 Jun 2018
+ by sstaub
  http://www.arduino.cc/en/Tutorial/WebClientRepeating
  This code is in the public domain.
 
@@ -24,11 +25,6 @@
 #include <LwIP.h>
 #include <STM32Ethernet.h>
 
-// assign a MAC address for the ethernet controller.
-// fill in your address here:
-byte mac[] = {
-  0xDE, 0xAD, 0xBE, 0xEF, 0xFE, 0xED
-};
 // fill in an available IP address on your network here,
 // for manual configuration:
 IPAddress ip(192, 168, 1, 177);
@@ -56,7 +52,7 @@ void setup() {
   // give the ethernet module time to boot up:
   delay(1000);
   // start the Ethernet connection using a fixed IP address and DNS server:
-  Ethernet.begin(mac, ip, myDns);
+  Ethernet.begin(ip, myDns);
   // print the Ethernet board/shield's IP address:
   Serial.print("My IP address: ");
   Serial.println(Ethernet.localIP());

--- a/examples/WebServer/WebServer.ino
+++ b/examples/WebServer/WebServer.ino
@@ -15,17 +15,15 @@
  by Arturo Guadalupi
  modified 23 Jun 2017
  by Wi6Labs
-
+ modified 1 Jun 2018
+ by sstaub
  */
 
 #include <LwIP.h>
 #include <STM32Ethernet.h>
 
-// Enter a MAC address and IP address for your controller below.
+// Enter an IP address for your controller below.
 // The IP address will be dependent on your local network:
-byte mac[] = {
-  0xDE, 0xAD, 0xBE, 0xEF, 0xFE, 0xED
-};
 IPAddress ip(192, 168, 1, 177);
 
 // Initialize the Ethernet server library
@@ -42,7 +40,7 @@ void setup() {
 
 
   // start the Ethernet connection and the server:
-  Ethernet.begin(mac, ip);
+  Ethernet.begin(ip);
   server.begin();
   Serial.print("server is at ");
   Serial.println(Ethernet.localIP());

--- a/keywords.txt
+++ b/keywords.txt
@@ -32,6 +32,7 @@ remoteIP	KEYWORD2
 remotePort	KEYWORD2
 getSocketNumber	KEYWORD2
 localIP	KEYWORD2
+macAddress	KEYWORD2
 maintain	KEYWORD2
 
 #######################################

--- a/src/STM32Ethernet.cpp
+++ b/src/STM32Ethernet.cpp
@@ -5,9 +5,6 @@ int EthernetClass::begin(unsigned long timeout, unsigned long responseTimeout)
 {
   static DhcpClass s_dhcp;
   _dhcp = &s_dhcp;
-  //uint8_t mac_address[6];
-  //macAddressDefault(mac_address);
-  //stm32_eth_init(mac_address, NULL, NULL, NULL);
   stm32_eth_init(macAddressDefault(), NULL, NULL, NULL);
 
   // Now try to get our config info from a DHCP server
@@ -46,9 +43,6 @@ void EthernetClass::begin(IPAddress local_ip, IPAddress subnet, IPAddress gatewa
 
 void EthernetClass::begin(IPAddress local_ip, IPAddress subnet, IPAddress gateway, IPAddress dns_server)
 {
-  //uint8_t mac_address[6];
-  //macAddressDefault(mac_address);
-  //stm32_eth_init(mac_address, local_ip.raw_address(), gateway.raw_address(), subnet.raw_address());
   stm32_eth_init(macAddressDefault(), local_ip.raw_address(), gateway.raw_address(), subnet.raw_address());
   /* If there is a local DHCP informs it of our manual IP configuration to
   prevent IP conflict */

--- a/src/STM32Ethernet.cpp
+++ b/src/STM32Ethernet.cpp
@@ -69,7 +69,7 @@ int EthernetClass::begin(uint8_t *mac_address, unsigned long timeout, unsigned l
   {
     _dnsServerAddress = _dhcp->getDnsServerIp();
   }
-
+  macAddress(mac_address);
   return ret;
 }
 
@@ -104,6 +104,7 @@ void EthernetClass::begin(uint8_t *mac, IPAddress local_ip, IPAddress dns_server
   prevent IP conflict */
   stm32_DHCP_manual_config();
   _dnsServerAddress = dns_server;
+  macAddress(mac);
 }
 
 int EthernetClass::maintain(){
@@ -139,7 +140,7 @@ void EthernetClass::schedule(void)
 
 uint8_t * EthernetClass::macAddressDefault(void)
 {
-  if ((mac_address[0] == 0) && (mac_address[1] == 0) && (mac_address[2] == 0) && (mac_address[3] == 0) && (mac_address[4] == 0) && (mac_address[5] == 0)) {
+  if ((mac_address[0] + mac_address[1] + mac_address[2] + mac_address[3] + mac_address[4] + mac_address[5]) == 0) {
     uint32_t baseUID = *(uint32_t *)UID_BASE;
     mac_address[0] = 0x00;
     mac_address[1] = 0x80;

--- a/src/STM32Ethernet.h
+++ b/src/STM32Ethernet.h
@@ -12,17 +12,18 @@ private:
   IPAddress _dnsServerAddress;
   DhcpClass* _dhcp;
 public:
-  // Initialise the Ethernet shield to use the provided MAC address and gain the rest of the
+  // Initialise the Ethernet with the internal provided MAC address and gain the rest of the
   // configuration through DHCP.
   // Returns 0 if the DHCP configuration failed, and 1 if it succeeded
-  int begin(uint8_t *mac_address, unsigned long timeout = 60000, unsigned long responseTimeout = 4000);
-  void begin(uint8_t *mac_address, IPAddress local_ip);
-  void begin(uint8_t *mac_address, IPAddress local_ip, IPAddress dns_server);
-  void begin(uint8_t *mac_address, IPAddress local_ip, IPAddress dns_server, IPAddress gateway);
-  void begin(uint8_t *mac_address, IPAddress local_ip, IPAddress dns_server, IPAddress gateway, IPAddress subnet);
+  int begin(unsigned long timeout = 60000, unsigned long responseTimeout = 4000);
+  void begin(IPAddress local_ip);
+  void begin(IPAddress local_ip, IPAddress subnet);
+  void begin(IPAddress local_ip, IPAddress subnet, IPAddress gateway);
+  void begin(IPAddress local_ip, IPAddress subnet, IPAddress gateway, IPAddress dns_server);
   int maintain();
   void schedule(void);
 
+  void macAddress(uint8_t *mac);
   IPAddress localIP();
   IPAddress subnetMask();
   IPAddress gatewayIP();

--- a/src/STM32Ethernet.h
+++ b/src/STM32Ethernet.h
@@ -11,6 +11,9 @@ class EthernetClass {
 private:
   IPAddress _dnsServerAddress;
   DhcpClass* _dhcp;
+  uint8_t mac_address[6];
+  uint8_t *  macAddressDefault(void);
+  
 public:
   // Initialise the Ethernet with the internal provided MAC address and gain the rest of the
   // configuration through DHCP.
@@ -20,10 +23,21 @@ public:
   void begin(IPAddress local_ip, IPAddress subnet);
   void begin(IPAddress local_ip, IPAddress subnet, IPAddress gateway);
   void begin(IPAddress local_ip, IPAddress subnet, IPAddress gateway, IPAddress dns_server);
+  // Initialise the Ethernet shield to use the provided MAC address and gain the rest of the
+  // configuration through DHCP.
+  // Returns 0 if the DHCP configuration failed, and 1 if it succeeded
+  int begin(uint8_t *mac_address, unsigned long timeout = 60000, unsigned long responseTimeout = 4000);
+  void begin(uint8_t *mac_address, IPAddress local_ip);
+  void begin(uint8_t *mac_address, IPAddress local_ip, IPAddress dns_server);
+  void begin(uint8_t *mac_address, IPAddress local_ip, IPAddress dns_server, IPAddress gateway);
+  void begin(uint8_t *mac_address, IPAddress local_ip, IPAddress dns_server, IPAddress gateway, IPAddress subnet);
+
+
   int maintain();
   void schedule(void);
-
+  
   void macAddress(uint8_t *mac);
+  uint8_t * macAddress(void);
   IPAddress localIP();
   IPAddress subnetMask();
   IPAddress gatewayIP();


### PR DESCRIPTION
- 1. This PR supports the internal MAC address like on mbed
- 2. Changed init procedure like on Ethernet3 (https://github.com/sstaub/Ethernet3) library, it is now `Ethernet.begin(ip, subnet, gateway, dns)` which is more common
- tested with STM32F429 Nucleo
- tested with STM32F746 Discovery
- updated readme.md and examples