### PR TITLE
Support for PlatformIO library manager

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,0 +1,13 @@
+{
+  "name": "STM32Ethernet",
+  "keywords": "Ethernet",
+  "description": "Arduino library to support Ethernet for STM32 based board.",
+  "repository":
+  {
+    "type": "git",
+    "url": "https://github.com/stm32duino/STM32Ethernet"
+  },
+  "version": "1.0.4",
+  "frameworks": "arduino",
+  "platforms": "ststm32"
+}

--- a/library.json
+++ b/library.json
@@ -7,7 +7,10 @@
     "type": "git",
     "url": "https://github.com/stm32duino/STM32Ethernet"
   },
-  "version": "1.0.4",
+  "version": "1.0.5",
   "frameworks": "arduino",
-  "platforms": "ststm32"
+  "platforms": "ststm32",
+  "build": {
+    "libArchive": false
+  }
 }


### PR DESCRIPTION
This file addition includes the support for the PlatformIO library manager.
With some adaptations it can used for all the libraries.
After making the PR, the library can be registered. I can do this.
https://docs.platformio.org/en/latest/librarymanager/creating.html#register