### PR TITLE
client: Fix bool operator on init and ongoing use

### DIFF
--- a/src/EthernetClient.cpp
+++ b/src/EthernetClient.cpp
@@ -9,12 +9,14 @@ extern "C" {
 #include "EthernetServer.h"
 #include "Dns.h"
 
-EthernetClient::EthernetClient() {
+EthernetClient::EthernetClient()
+  :_tcp_client(NULL) {
 }
 
 /* Deprecated constructor. Keeps compatibility with W5100 architecture
 sketches but sock is ignored. */
-EthernetClient::EthernetClient(uint8_t sock) {
+EthernetClient::EthernetClient(uint8_t sock)
+  :_tcp_client(NULL) {
   UNUSED(sock);
 }
 
@@ -181,7 +183,7 @@ uint8_t EthernetClient::status() {
 // EthernetServer::available() as the condition in an if-statement.
 
 EthernetClient::operator bool() {
-  return _tcp_client != NULL;
+  return (_tcp_client && (_tcp_client->state != TCP_CLOSING));
 }
 
 bool EthernetClient::operator==(const EthernetClient& rhs) {

--- a/src/EthernetServer.cpp
+++ b/src/EthernetServer.cpp
@@ -9,6 +9,8 @@ extern "C" {
 EthernetServer::EthernetServer(uint16_t port)
 {
   _port = port;
+  _tcp_client[MAX_CLIENT] = {};
+  _tcp_server = {};
 }
 
 void EthernetServer::begin()

--- a/src/EthernetServer.h
+++ b/src/EthernetServer.h
@@ -14,7 +14,7 @@ private:
   
   void accept(void);
 public:
-  EthernetServer(uint16_t);
+  EthernetServer(uint16_t port = 80);
   EthernetClient available();
   virtual void begin();
   virtual size_t write(uint8_t);


### PR DESCRIPTION
When iterating we make sure client's socket is not closing
since _tcp_client remains after close.

This was tested on nuleo-f767zi using project webthing-arduino

Change-Id: Ie465fe59009c33957dad97f1c70b4dc3af3b2ebe
Signed-off-by: Philippe Coval <p.coval@samsung.com>