### PR TITLE
Allocate the TCP client when needed.

### DIFF
--- a/src/EthernetClient.cpp
+++ b/src/EthernetClient.cpp
@@ -40,16 +40,13 @@ int EthernetClient::connect(const char* host, uint16_t port) {
 }
 
 int EthernetClient::connect(IPAddress ip, uint16_t port) {
-  /* Can't create twice the same client */
-  if(_tcp_client != NULL) {
-    return 0;
-  }
-
-  /* Allocates memory for client */
-  _tcp_client = (struct tcp_struct *)mem_malloc(sizeof(struct tcp_struct));
-
   if(_tcp_client == NULL) {
-    return 0;
+    /* Allocates memory for client */
+    _tcp_client = (struct tcp_struct *)mem_malloc(sizeof(struct tcp_struct));
+
+    if(_tcp_client == NULL) {
+        return 0;
+    }
   }
 
   /* Creates a new TCP protocol control block */


### PR DESCRIPTION
This patch allows the WebClientRepeating example to work. I suspect this will also fix #22. Also fixes one of the SSLClient examples.

Without this patch, only the first connect succeeds. The following attempts fail because _tcp_client is not NULL.