### PR TITLE
Add Ethernet.linkStatus

### DIFF
--- a/src/STM32Ethernet.cpp
+++ b/src/STM32Ethernet.cpp
@@ -101,6 +101,11 @@ void EthernetClass::begin(uint8_t *mac, IPAddress local_ip, IPAddress dns_server
   macAddress(mac);
 }
 
+EthernetLinkStatus EthernetClass::linkStatus()
+{
+  return (stm32_eth_link_up() ? LinkON : LinkOFF);
+}
+
 int EthernetClass::maintain(){
   int rc = DHCP_CHECK_NONE;
 

--- a/src/STM32Ethernet.h
+++ b/src/STM32Ethernet.h
@@ -7,6 +7,12 @@
 #include "EthernetServer.h"
 #include "Dhcp.h"
 
+enum EthernetLinkStatus {
+  Unknown,
+  LinkON,
+  LinkOFF
+};
+
 class EthernetClass {
 private:
   IPAddress _dnsServerAddress;
@@ -19,6 +25,7 @@ public:
   // configuration through DHCP.
   // Returns 0 if the DHCP configuration failed, and 1 if it succeeded
   int begin(unsigned long timeout = 60000, unsigned long responseTimeout = 4000);
+  EthernetLinkStatus linkStatus();
   void begin(IPAddress local_ip);
   void begin(IPAddress local_ip, IPAddress subnet);
   void begin(IPAddress local_ip, IPAddress subnet, IPAddress gateway);

--- a/src/utility/stm32_eth.cpp
+++ b/src/utility/stm32_eth.cpp
@@ -247,6 +247,15 @@ void stm32_eth_init(const uint8_t *mac, const uint8_t *ip, const uint8_t *gw, co
 }
 
 /**
+  * @brief Return Ethernet link status
+  * @param  None
+  * @retval 1 for link up, 0 for link down
+  */
+uint8_t stm32_eth_link_up(void) {
+  return netif_is_link_up(&gnetif);
+}
+
+/**
   * @brief  This function must be called in main loop in standalone mode.
   * @param  None
   * @retval None
@@ -479,8 +488,6 @@ void ethernetif_notify_conn_changed(struct netif *netif)
 {
   if(netif_is_link_up(netif))
   {
-    printf("Link up\n");
-
     /* Update DHCP state machine if DHCP used */
     if(DHCP_Started_by_user == 1) {
       DHCP_state = DHCP_START;
@@ -498,8 +505,6 @@ void ethernetif_notify_conn_changed(struct netif *netif)
 
     /*  When the netif link is down this function must be called.*/
     netif_set_down(netif);
-
-    printf("Link down\n");
   }
 }
 

--- a/src/utility/stm32_eth.h
+++ b/src/utility/stm32_eth.h
@@ -121,6 +121,7 @@ extern struct netif gnetif;
 
 /* Exported functions ------------------------------------------------------- */
 void stm32_eth_init(const uint8_t *mac, const uint8_t *ip, const uint8_t *gw, const uint8_t *netmask);
+uint8_t stm32_eth_link_up(void);
 void stm32_eth_scheduler(void);
 
 void User_notification(struct netif *netif);


### PR DESCRIPTION
Also remove 2 printf debug. Should close #19. Here is the test code.

```
#include <LwIP.h>
#include <STM32Ethernet.h>

// Initialize the Ethernet client library
// with the IP address and port of the server
// that you want to connect to (port 80 is default for HTTP):
EthernetClient client;

void setup() {
  // Open serial communications and wait for port to open:
  Serial.begin(115200);
  Serial.println("Ethernet.linkStatus test");
  while (!Serial) {
    ; // wait for serial port to connect. Needed for native USB port only
  }
  // start the Ethernet connection:
  if (Ethernet.begin() == 0) {
    Serial.println("Failed to configure Ethernet using DHCP");
    // no point in carrying on, so do nothing forevermore:
    for (;;)
      ;
  }
}

void loop () {
  if (Ethernet.linkStatus() == Unknown) {
    Serial.println("Link status unknown.");
  }
  else if (Ethernet.linkStatus() == LinkON) {
    Serial.println("Link status: On");
  }
  else if (Ethernet.linkStatus() == LinkOFF) {
    Serial.println("Link status: Off");
  }
  delay(250);
}
```