### PR TITLE
HardwareTimer: remove usage of TIMER_OUTPUT_COMPARE mode

### DIFF
--- a/src/lwipopts.h
+++ b/src/lwipopts.h
@@ -9,12 +9,12 @@
 
 /* LwIP specific configuration options. */
 #if __has_include("STM32lwipopts.h")
-#include "STM32lwipopts.h"
+  #include "STM32lwipopts.h"
 #else
-#if __has_include("lwipopts_extra.h")
-#include "lwipopts_extra.h"
-#endif
-#include "lwipopts_default.h"
+  #if __has_include("lwipopts_extra.h")
+    #include "lwipopts_extra.h"
+  #endif
+  #include "lwipopts_default.h"
 #endif
 
 #endif /* _ARDUINO_LWIPOPTS_H */

--- a/src/lwipopts_default.h
+++ b/src/lwipopts_default.h
@@ -151,35 +151,35 @@ The STM32F4x7 allows computing and verifying the IP, UDP, TCP and ICMP checksums
 
 
 #ifdef CHECKSUM_BY_HARDWARE
-/* CHECKSUM_GEN_IP==0: Generate checksums by hardware for outgoing IP packets.*/
-#define CHECKSUM_GEN_IP                 0
-/* CHECKSUM_GEN_UDP==0: Generate checksums by hardware for outgoing UDP packets.*/
-#define CHECKSUM_GEN_UDP                0
-/* CHECKSUM_GEN_TCP==0: Generate checksums by hardware for outgoing TCP packets.*/
-#define CHECKSUM_GEN_TCP                0
-/* CHECKSUM_CHECK_IP==0: Check checksums by hardware for incoming IP packets.*/
-#define CHECKSUM_CHECK_IP               0
-/* CHECKSUM_CHECK_UDP==0: Check checksums by hardware for incoming UDP packets.*/
-#define CHECKSUM_CHECK_UDP              0
-/* CHECKSUM_CHECK_TCP==0: Check checksums by hardware for incoming TCP packets.*/
-#define CHECKSUM_CHECK_TCP              0
-/* CHECKSUM_CHECK_ICMP==0: Check checksums by hardware for incoming ICMP packets.*/
-#define CHECKSUM_GEN_ICMP               0
+  /* CHECKSUM_GEN_IP==0: Generate checksums by hardware for outgoing IP packets.*/
+  #define CHECKSUM_GEN_IP                 0
+  /* CHECKSUM_GEN_UDP==0: Generate checksums by hardware for outgoing UDP packets.*/
+  #define CHECKSUM_GEN_UDP                0
+  /* CHECKSUM_GEN_TCP==0: Generate checksums by hardware for outgoing TCP packets.*/
+  #define CHECKSUM_GEN_TCP                0
+  /* CHECKSUM_CHECK_IP==0: Check checksums by hardware for incoming IP packets.*/
+  #define CHECKSUM_CHECK_IP               0
+  /* CHECKSUM_CHECK_UDP==0: Check checksums by hardware for incoming UDP packets.*/
+  #define CHECKSUM_CHECK_UDP              0
+  /* CHECKSUM_CHECK_TCP==0: Check checksums by hardware for incoming TCP packets.*/
+  #define CHECKSUM_CHECK_TCP              0
+  /* CHECKSUM_CHECK_ICMP==0: Check checksums by hardware for incoming ICMP packets.*/
+  #define CHECKSUM_GEN_ICMP               0
 #else
-/* CHECKSUM_GEN_IP==1: Generate checksums in software for outgoing IP packets.*/
-#define CHECKSUM_GEN_IP                 1
-/* CHECKSUM_GEN_UDP==1: Generate checksums in software for outgoing UDP packets.*/
-#define CHECKSUM_GEN_UDP                1
-/* CHECKSUM_GEN_TCP==1: Generate checksums in software for outgoing TCP packets.*/
-#define CHECKSUM_GEN_TCP                1
-/* CHECKSUM_CHECK_IP==1: Check checksums in software for incoming IP packets.*/
-#define CHECKSUM_CHECK_IP               1
-/* CHECKSUM_CHECK_UDP==1: Check checksums in software for incoming UDP packets.*/
-#define CHECKSUM_CHECK_UDP              1
-/* CHECKSUM_CHECK_TCP==1: Check checksums in software for incoming TCP packets.*/
-#define CHECKSUM_CHECK_TCP              1
-/* CHECKSUM_CHECK_ICMP==1: Check checksums by hardware for incoming ICMP packets.*/
-#define CHECKSUM_GEN_ICMP               1
+  /* CHECKSUM_GEN_IP==1: Generate checksums in software for outgoing IP packets.*/
+  #define CHECKSUM_GEN_IP                 1
+  /* CHECKSUM_GEN_UDP==1: Generate checksums in software for outgoing UDP packets.*/
+  #define CHECKSUM_GEN_UDP                1
+  /* CHECKSUM_GEN_TCP==1: Generate checksums in software for outgoing TCP packets.*/
+  #define CHECKSUM_GEN_TCP                1
+  /* CHECKSUM_CHECK_IP==1: Check checksums in software for incoming IP packets.*/
+  #define CHECKSUM_CHECK_IP               1
+  /* CHECKSUM_CHECK_UDP==1: Check checksums in software for incoming UDP packets.*/
+  #define CHECKSUM_CHECK_UDP              1
+  /* CHECKSUM_CHECK_TCP==1: Check checksums in software for incoming TCP packets.*/
+  #define CHECKSUM_CHECK_TCP              1
+  /* CHECKSUM_CHECK_ICMP==1: Check checksums by hardware for incoming ICMP packets.*/
+  #define CHECKSUM_GEN_ICMP               1
 #endif
 
 

--- a/src/utility/ethernetif.cpp
+++ b/src/utility/ethernetif.cpp
@@ -54,7 +54,7 @@
 #include "lwip/igmp.h"
 #include "stm32_eth.h"
 #if !defined(STM32_CORE_VERSION) || (STM32_CORE_VERSION  <= 0x01050000)
-#include "variant.h"
+  #include "variant.h"
 #endif
 
 #ifdef __cplusplus

--- a/src/utility/stm32_eth.cpp
+++ b/src/utility/stm32_eth.cpp
@@ -63,8 +63,8 @@
  *       They could be used for this library when available
  */
 #ifndef DEFAULT_ETHERNET_TIMER
-#define DEFAULT_ETHERNET_TIMER  TIM14
-#warning "Default timer used to call ethernet scheduler at regular interval: TIM14"
+  #define DEFAULT_ETHERNET_TIMER  TIM14
+  #warning "Default timer used to call ethernet scheduler at regular interval: TIM14"
 #endif
 
 /* Ethernet configuration: user parameters */
@@ -93,8 +93,8 @@ static uint8_t DHCP_Started_by_user = 0;
 static uint32_t gEhtLinkTickStart = 0;
 
 #if !defined(STM32_CORE_VERSION) || (STM32_CORE_VERSION  <= 0x01060100)
-/* Handler for stimer */
-static stimer_t TimHandle;
+  /* Handler for stimer */
+  static stimer_t TimHandle;
 #endif
 
 /*************************** Function prototype *******************************/
@@ -137,11 +137,11 @@ static void Netif_Config(void)
 * @retval None
 */
 #if !defined(STM32_CORE_VERSION) || (STM32_CORE_VERSION  <= 0x01060100)
-static void scheduler_callback(stimer_t *htim)
+  static void scheduler_callback(stimer_t *htim)
 #elif (STM32_CORE_VERSION  <= 0x01080000)
-static void scheduler_callback(HardwareTimer *htim)
+  static void scheduler_callback(HardwareTimer *htim)
 #else
-static void scheduler_callback(void)
+  static void scheduler_callback(void)
 #endif
 {
 #if (STM32_CORE_VERSION  <= 0x01080000)

--- a/src/utility/stm32_eth.cpp
+++ b/src/utility/stm32_eth.cpp
@@ -176,7 +176,6 @@ static void TIM_scheduler_Config(void)
 {
   /* Configure HardwareTimer */
   HardwareTimer *EthTim = new HardwareTimer(DEFAULT_ETHERNET_TIMER);
-  EthTim->setMode(1, TIMER_OUTPUT_COMPARE);
 
   /* Timer set to 1ms */
   EthTim->setOverflow(1000, MICROSEC_FORMAT);

--- a/src/utility/stm32_eth.h
+++ b/src/utility/stm32_eth.h
@@ -112,7 +112,7 @@ struct tcp_struct {
 #define MAX_CLIENT  32
 
 #ifdef ETH_INPUT_USE_IT
-extern struct netif gnetif;
+  extern struct netif gnetif;
 #endif
 
 
@@ -125,22 +125,22 @@ void stm32_eth_scheduler(void);
 void User_notification(struct netif *netif);
 
 #if LWIP_DHCP
-void stm32_DHCP_Process(struct netif *netif);
-void stm32_DHCP_Periodic_Handle(struct netif *netif);
-void stm32_DHCP_manual_config(void);
-uint8_t stm32_get_DHCP_lease_state(void);
-void stm32_set_DHCP_state(uint8_t state);
-uint8_t stm32_get_DHCP_state(void);
-uint8_t stm32_dhcp_started(void);
+  void stm32_DHCP_Process(struct netif *netif);
+  void stm32_DHCP_Periodic_Handle(struct netif *netif);
+  void stm32_DHCP_manual_config(void);
+  uint8_t stm32_get_DHCP_lease_state(void);
+  void stm32_set_DHCP_state(uint8_t state);
+  uint8_t stm32_get_DHCP_state(void);
+  uint8_t stm32_dhcp_started(void);
 #else
-#error "LWIP_DHCP must be enabled in lwipopts.h"
+  #error "LWIP_DHCP must be enabled in lwipopts.h"
 #endif
 
 #if LWIP_DNS
-void stm32_dns_init(const uint8_t *dnsaddr);
-int8_t stm32_dns_gethostbyname(const char *hostname, uint32_t *ipaddr);
+  void stm32_dns_init(const uint8_t *dnsaddr);
+  int8_t stm32_dns_gethostbyname(const char *hostname, uint32_t *ipaddr);
 #else
-#error "LWIP_DNS must be enabled in lwipopts.h"
+  #error "LWIP_DNS must be enabled in lwipopts.h"
 #endif
 
 #if LWIP_UDP
@@ -164,11 +164,11 @@ ip_addr_t *u8_to_ip_addr(uint8_t *ipu8, ip_addr_t *ipaddr);
 uint32_t ip_addr_to_u32(ip_addr_t *ipaddr);
 
 #if LWIP_TCP
-err_t tcp_connected_callback(void *arg, struct tcp_pcb *tpcb, err_t err);
-err_t tcp_accept_callback(void *arg, struct tcp_pcb *newpcb, err_t err);
-void tcp_connection_close(struct tcp_pcb *tpcb, struct tcp_struct *tcp);
+  err_t tcp_connected_callback(void *arg, struct tcp_pcb *tpcb, err_t err);
+  err_t tcp_accept_callback(void *arg, struct tcp_pcb *newpcb, err_t err);
+  void tcp_connection_close(struct tcp_pcb *tpcb, struct tcp_struct *tcp);
 #else
-#error "LWIP_TCP must be enabled in lwipopts.h"
+  #error "LWIP_TCP must be enabled in lwipopts.h"
 #endif
 
 #endif /* __STM32_ETH_H__ */


### PR DESCRIPTION
HardwareTimer: remove usage of TIMER_OUTPUT_COMPARE mode

With introduction of PR
https://github.com/stm32duino/Arduino_Core_STM32/pull/1247
Usage of TIMER_OUTPUT_COMPARE becomes obsolete.
Note: removing setMode(1, TIMER_OUTPUT_COMPARE)
also works before PR #1247.
