### PR TITLE
Fix : Wrong _tcp_client[] array initialization

### DIFF
--- a/src/EthernetServer.cpp
+++ b/src/EthernetServer.cpp
@@ -9,7 +9,9 @@ extern "C" {
 EthernetServer::EthernetServer(uint16_t port)
 {
   _port = port;
-  _tcp_client[MAX_CLIENT] = {};
+  for (int i = 0; i < MAX_CLIENT; i++) {
+    _tcp_client[i] = {};
+  }
   _tcp_server = {};
 }
 


### PR DESCRIPTION
Fix : Wrong _tcp_client[] array initialization

Former "_tcp_client[MAX_CLIENT] = {};" tries to initialize
the array element with index MAX_CLIENT,
which is out of array range [0 .. (MAX_CLIENT-1)]
Fixes warning:
warning: array subscript 32 is above array bounds of 'tcp_struct* [32]' [-Warray-bounds]

Instead initialize each element of the array one by one.

Signed-off-by: Alexandre Bourdiol <alexandre.bourdiol@st.com>