### PR TITLE
feat: Add function to define port of EthernetServer at runtime

### DIFF
--- a/src/EthernetServer.cpp
+++ b/src/EthernetServer.cpp
@@ -40,6 +40,12 @@ void EthernetServer::begin()
   tcp_accept(_tcp_server.pcb, tcp_accept_callback);
 }
 
+void EthernetServer::begin(uint16_t port)
+{
+  _port = port;
+  begin();
+}
+
 void EthernetServer::accept()
 {
   /* Free client if disconnected */

--- a/src/EthernetServer.h
+++ b/src/EthernetServer.h
@@ -17,6 +17,7 @@ class EthernetServer :
     EthernetServer(uint16_t port = 80);
     EthernetClient available();
     virtual void begin();
+    virtual void begin(uint16_t port);
     virtual size_t write(uint8_t);
     virtual size_t write(const uint8_t *buf, size_t size);
     using Print::write;


### PR DESCRIPTION
I use the `EthernetServer `class but I must read the port to be used from a configuration file on an SD Card at runtime.
As the port is optionally defined in the constructor and only used in the `begin()` function, I added a `begin(uint16_t port)` function to set port if needed,