### PR TITLE
fix(client): setTimeout shadows Stream.setTimeout

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -24,7 +24,9 @@ peek	KEYWORD2
 flush	KEYWORD2
 stop	KEYWORD2
 connected	KEYWORD2
+accept	KEYWORD2
 begin	KEYWORD2
+beginMulticast	KEYWORD2
 beginPacket	KEYWORD2
 endPacket	KEYWORD2
 parsePacket	KEYWORD2
@@ -32,11 +34,17 @@ remoteIP	KEYWORD2
 remotePort	KEYWORD2
 getSocketNumber	KEYWORD2
 localIP	KEYWORD2
-MACAddress	KEYWORD2
+localPort	KEYWORD2
 maintain	KEYWORD2
+linkStatus	KEYWORD2
+MACAddress	KEYWORD2
+subnetMask	KEYWORD2
+gatewayIP	KEYWORD2
+dnsServerIP	KEYWORD2
 setConnectionTimeout	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)
 #######################################
-
+LinkON	LITERAL1
+LinkOFF	LITERAL1

--- a/keywords.txt
+++ b/keywords.txt
@@ -34,6 +34,7 @@ getSocketNumber	KEYWORD2
 localIP	KEYWORD2
 MACAddress	KEYWORD2
 maintain	KEYWORD2
+setConnectionTimeout	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)

--- a/src/EthernetClient.cpp
+++ b/src/EthernetClient.cpp
@@ -76,7 +76,7 @@ int EthernetClient::connect(IPAddress ip, uint16_t port)
   startTime = millis();
   while (_tcp_client->state == TCP_NONE) {
     stm32_eth_scheduler();
-    if ((_tcp_client->state == TCP_CLOSING) || ((millis() - startTime) >= _timeout)) {
+    if ((_tcp_client->state == TCP_CLOSING) || ((millis() - startTime) >= _connectionTimeout)) {
       stop();
       return 0;
     }

--- a/src/EthernetClient.h
+++ b/src/EthernetClient.h
@@ -52,9 +52,9 @@ class EthernetClient : public Client {
     {
       return (_tcp_client->pcb->remote_port);
     };
-    void setTimeout(uint16_t timeout)
+    void setConnectionTimeout(uint16_t timeout)
     {
-      _timeout = timeout;
+      _connectionTimeout = timeout;
     }
 
     friend class EthernetServer;
@@ -63,7 +63,7 @@ class EthernetClient : public Client {
 
   private:
     struct tcp_struct *_tcp_client;
-    uint16_t _timeout = 10000;
+    uint16_t _connectionTimeout = 10000;
 };
 
 #endif


### PR DESCRIPTION
Rename it `setConnectionTimeout` to match Arduino Ethernet API.

https://www.arduino.cc/reference/en/libraries/ethernet/client.setconnectiontimeout/

Fixes #72