### PR TITLE
Fixing bug that caused large memory consumption

### DIFF
--- a/src/EthernetClient.cpp
+++ b/src/EthernetClient.cpp
@@ -194,6 +194,7 @@ void EthernetClient::stop()
   if (status() != TCP_CLOSING) {
     tcp_connection_close(_tcp_client->pcb, _tcp_client);
   }
+  mem_free(_tcp_client);
 }
 
 uint8_t EthernetClient::connected()


### PR DESCRIPTION
As listed in issue #75, there is an error that caused large memory usage in the `EthernetClient`module. These changes fix the mentioned memory bug. 