### PR TITLE
feat(server): add bool operator and end() api

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,4 +66,4 @@ Call `Ethernet::schedule()` performs an update of the LwIP stack.<br>
 
 ## Wiki
 
-You can find information at https://github.com/stm32duino/wiki/wiki/STM32Ethernet
+You can find information at https://github.com/stm32duino/Arduino_Core_STM32/wiki/STM32Ethernet

--- a/src/EthernetServer.cpp
+++ b/src/EthernetServer.cpp
@@ -46,6 +46,22 @@ void EthernetServer::begin(uint16_t port)
   begin();
 }
 
+void EthernetServer::end(void)
+{
+  /* Free client */
+  for (int n = 0; n < MAX_CLIENT; n++) {
+    if (_tcp_client[n] != NULL) {
+      EthernetClient client(_tcp_client[n]);
+      client.stop();
+      _tcp_client[n] = NULL;
+    }
+  }
+  if (_tcp_server.pcb != NULL) {
+    tcp_close(_tcp_server.pcb);
+    _tcp_server.pcb = NULL;
+  }
+}
+
 void EthernetServer::accept()
 {
   /* Free client if disconnected */

--- a/src/EthernetServer.cpp
+++ b/src/EthernetServer.cpp
@@ -93,10 +93,10 @@ size_t EthernetServer::write(const uint8_t *buffer, size_t size)
 
   accept();
 
-  for (int n = 0; n < MAX_CLIENT; n++) {
-    if (_tcp_client[n] != NULL) {
-      if (_tcp_client[n]->pcb != NULL) {
-        EthernetClient client(_tcp_client[n]);
+  for (int i = 0; i < MAX_CLIENT; i++) {
+    if (_tcp_client[i] != NULL) {
+      if (_tcp_client[i]->pcb != NULL) {
+        EthernetClient client(_tcp_client[i]);
         uint8_t s = client.status();
         if (s == TCP_ACCEPTED) {
           n += client.write(buffer, size);

--- a/src/EthernetServer.cpp
+++ b/src/EthernetServer.cpp
@@ -107,3 +107,9 @@ size_t EthernetServer::write(const uint8_t *buffer, size_t size)
 
   return n;
 }
+
+EthernetServer::operator bool()
+{
+  // server is listening for incoming clients
+  return ((_tcp_server.pcb != NULL) && (_tcp_server.pcb->state == LISTEN));
+}

--- a/src/EthernetServer.h
+++ b/src/EthernetServer.h
@@ -18,6 +18,7 @@ class EthernetServer :
     EthernetClient available();
     virtual void begin();
     virtual void begin(uint16_t port);
+    void end(void);
     virtual size_t write(uint8_t);
     virtual size_t write(const uint8_t *buf, size_t size);
     virtual operator bool();

--- a/src/EthernetServer.h
+++ b/src/EthernetServer.h
@@ -20,6 +20,7 @@ class EthernetServer :
     virtual void begin(uint16_t port);
     virtual size_t write(uint8_t);
     virtual size_t write(const uint8_t *buf, size_t size);
+    virtual operator bool();
     using Print::write;
 };
 


### PR DESCRIPTION
* bool operator:
https://www.arduino.cc/reference/en/libraries/ethernet/ifserver/

* `end()`:
Not officially documented. Pay attention, when `end()` is called, the socket is not close immediately. The tcp connection will come into `TCP_WAIT`,  after few minutes (~2 minutes) the connection will close completely and free the socket.
So calling `begin()` during this time frame after the `end() ` will silently failed and have to check thanks the bool operator if the server is ready or not. If not then call again `begin()`.

For `TCP_WAIT` ref: https://github.com/stm32duino/LwIP/blob/4de72d4b92ebf1ac5ce5efe7c331c0af6d52cca3/src/core/tcp.c#L1446C11-L1446C11

Fixes #73.