### PR TITLE
EthernetClass - add setDnsServerIP as in Arduino Ethernet library

### DIFF
--- a/src/STM32Ethernet.cpp
+++ b/src/STM32Ethernet.cpp
@@ -182,4 +182,9 @@ IPAddress EthernetClass::dnsServerIP()
   return _dnsServerAddress;
 }
 
+void EthernetClass::setDnsServerIP(const IPAddress dns_server)
+{
+  _dnsServerAddress = dns_server;
+}
+
 EthernetClass Ethernet;

--- a/src/STM32Ethernet.h
+++ b/src/STM32Ethernet.h
@@ -50,6 +50,8 @@ class EthernetClass {
     IPAddress gatewayIP();
     IPAddress dnsServerIP();
 
+    void setDnsServerIP(const IPAddress dns_server);
+
     friend class EthernetClient;
     friend class EthernetServer;
 };


### PR DESCRIPTION
EthernetClass - add setDnsServerIP as in Arduino Ethernet library

[overview](https://github.com/JAndrassy/Arduino-Networking-API/blob/main/ArduinoNetAPILibs.md#legacy-ethernet-getters-and-setters) of Ethernet legacy getters and setters in Arduino Ethernet libraries