### PR TITLE
EthernetClient.connect - return only 1 or 0

### DIFF
--- a/src/EthernetClient.cpp
+++ b/src/EthernetClient.cpp
@@ -39,7 +39,7 @@ int EthernetClient::connect(const char *host, uint16_t port)
   if (ret == 1) {
     return connect(remote_addr, port);
   } else {
-    return ret;
+    return 0;
   }
 }
 


### PR DESCRIPTION
All examples have `if (client.coonect(server, port)`, but `getHostName` doesn't return only 1 or 0, so `connect` can't return the return value of getHostName.