### PR TITLE
Fix: peek() function always return first byte of data

### DIFF
--- a/src/EthernetClient.cpp
+++ b/src/EthernetClient.cpp
@@ -171,7 +171,7 @@ int EthernetClient::peek()
   if (!available()) {
     return -1;
   }
-  b = pbuf_get_at(_tcp_client->data.p, 0);
+  b = pbuf_get_at(_tcp_client->data.p, _tcp_client->data.p->tot_len - _tcp_client->data.available);
   return b;
 }
 

--- a/src/EthernetUdp.cpp
+++ b/src/EthernetUdp.cpp
@@ -247,7 +247,7 @@ int EthernetUDP::peek()
   if (!_remaining) {
     return -1;
   }
-  b = pbuf_get_at(_udp.data.p, 0);
+  b = pbuf_get_at(_udp.data.p, _udp.data.p->tot_len - _udp.data.available);
   return b;
 }
 


### PR DESCRIPTION
Fix for issue #85
