### PR TITLE
fix: align MAC address api with Arduino reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ extend the default one by adding some extra configuration in a file named `lwipo
 
 ## New alternative init procedure **!!!**
 
-There are alternative inits of the Ethernetinterface with following orders:
+There are alternative inits of the Ethernet interface with following orders:
 
 	Ethernet.begin();
 	Ethernet.begin(ip);
@@ -39,16 +39,16 @@ There are alternative inits of the Ethernetinterface with following orders:
 
 This is more logical. A MAC address is no more needed and will retrieved internally by the mbed MAC address!
 
-You can get the MAC address with following function, this must done after Ethernet.Begin()
+You can get the MAC address with following function, this must be done after Ethernet.Begin()
 	
 	uint8_t *mac;
 	Ethernet.begin();
-	mac = Ethernet.MACAddress();
+	Ethernet.MACAddress(mac);
 
-You can also set a new user based MAC address, this must done before Ethernet.begin()
+You can also set a new user based MAC address, this must be done before Ethernet.begin()
 
 	uint8_t newMAC[] = {0x00, 0x80, 0xE1, 0x01, 0x01, 0x01};
-	Ethernet.MACAddress(newMAC);
+	Ethernet.setMACAddress(newMAC);
 	Ethernet.begin();
 
 ## Note

--- a/keywords.txt
+++ b/keywords.txt
@@ -38,9 +38,11 @@ localPort	KEYWORD2
 maintain	KEYWORD2
 linkStatus	KEYWORD2
 MACAddress	KEYWORD2
+setMACAddress	KEYWORD2
 subnetMask	KEYWORD2
 gatewayIP	KEYWORD2
 dnsServerIP	KEYWORD2
+setDnsServerIP	KEYWORD2
 setConnectionTimeout	KEYWORD2
 
 #######################################

--- a/src/Dhcp.cpp
+++ b/src/Dhcp.cpp
@@ -16,8 +16,12 @@ int DhcpClass::beginWithDHCP(uint8_t *mac, unsigned long timeout, unsigned long 
   // zero out _dhcpMacAddr
   memset(_dhcpMacAddr, 0, 6);
   reset_DHCP_lease();
-
-  memcpy((void *)_dhcpMacAddr, (void *)mac, 6);
+  if (mac == NULL) {
+    // use mac from Ethernet chip
+    stm32_eth_get_macaddr(_dhcpMacAddr);
+  } else {
+    memcpy((void *)_dhcpMacAddr, (void *)mac, 6);
+  }
   _dhcp_state = STATE_DHCP_START;
   stm32_set_DHCP_state(_dhcp_state);
   return request_DHCP_lease();

--- a/src/STM32Ethernet.cpp
+++ b/src/STM32Ethernet.cpp
@@ -5,7 +5,7 @@ int EthernetClass::begin(unsigned long timeout, unsigned long responseTimeout)
 {
   static DhcpClass s_dhcp;
   _dhcp = &s_dhcp;
-  stm32_eth_init(MACAddressDefault(), NULL, NULL, NULL);
+  stm32_eth_init(NULL, NULL, NULL, NULL);
 
   // Now try to get our config info from a DHCP server
   int ret = _dhcp->beginWithDHCP(mac_address, timeout, responseTimeout);
@@ -39,7 +39,7 @@ void EthernetClass::begin(IPAddress local_ip, IPAddress subnet, IPAddress gatewa
 
 void EthernetClass::begin(IPAddress local_ip, IPAddress subnet, IPAddress gateway, IPAddress dns_server)
 {
-  stm32_eth_init(MACAddressDefault(), local_ip.raw_address(), gateway.raw_address(), subnet.raw_address());
+  stm32_eth_init(NULL, local_ip.raw_address(), gateway.raw_address(), subnet.raw_address());
   /* If there is a local DHCP informs it of our manual IP configuration to
   prevent IP conflict */
   stm32_DHCP_manual_config();
@@ -131,20 +131,6 @@ int EthernetClass::maintain()
 void EthernetClass::schedule(void)
 {
   stm32_eth_scheduler();
-}
-
-uint8_t *EthernetClass::MACAddressDefault(void)
-{
-  if ((mac_address[0] + mac_address[1] + mac_address[2] + mac_address[3] + mac_address[4] + mac_address[5]) == 0) {
-    uint32_t baseUID = *(uint32_t *)UID_BASE;
-    mac_address[0] = 0x00;
-    mac_address[1] = 0x80;
-    mac_address[2] = 0xE1;
-    mac_address[3] = (baseUID & 0x00FF0000) >> 16;
-    mac_address[4] = (baseUID & 0x0000FF00) >> 8;
-    mac_address[5] = (baseUID & 0x000000FF);
-  }
-  return mac_address;
 }
 
 void EthernetClass::MACAddress(uint8_t *mac)

--- a/src/STM32Ethernet.cpp
+++ b/src/STM32Ethernet.cpp
@@ -8,7 +8,7 @@ int EthernetClass::begin(unsigned long timeout, unsigned long responseTimeout)
   stm32_eth_init(NULL, NULL, NULL, NULL);
 
   // Now try to get our config info from a DHCP server
-  int ret = _dhcp->beginWithDHCP(mac_address, timeout, responseTimeout);
+  int ret = _dhcp->beginWithDHCP(NULL, timeout, responseTimeout);
   if (ret == 1) {
     _dnsServerAddress = _dhcp->getDnsServerIp();
   }
@@ -58,7 +58,6 @@ int EthernetClass::begin(uint8_t *mac_address, unsigned long timeout, unsigned l
   if (ret == 1) {
     _dnsServerAddress = _dhcp->getDnsServerIp();
   }
-  MACAddress(mac_address);
   return ret;
 }
 
@@ -86,14 +85,13 @@ void EthernetClass::begin(uint8_t *mac_address, IPAddress local_ip, IPAddress dn
   begin(mac_address, local_ip, dns_server, gateway, subnet);
 }
 
-void EthernetClass::begin(uint8_t *mac, IPAddress local_ip, IPAddress dns_server, IPAddress gateway, IPAddress subnet)
+void EthernetClass::begin(uint8_t *mac_address, IPAddress local_ip, IPAddress dns_server, IPAddress gateway, IPAddress subnet)
 {
-  stm32_eth_init(mac, local_ip.raw_address(), gateway.raw_address(), subnet.raw_address());
+  stm32_eth_init(mac_address, local_ip.raw_address(), gateway.raw_address(), subnet.raw_address());
   /* If there is a local DHCP informs it of our manual IP configuration to
   prevent IP conflict */
   stm32_DHCP_manual_config();
   _dnsServerAddress = dns_server;
-  MACAddress(mac);
 }
 
 EthernetLinkStatus EthernetClass::linkStatus()
@@ -133,19 +131,14 @@ void EthernetClass::schedule(void)
   stm32_eth_scheduler();
 }
 
-void EthernetClass::MACAddress(uint8_t *mac)
+void EthernetClass::setMACAddress(const uint8_t *mac_address)
 {
-  mac_address[0] = mac[0];
-  mac_address[1] = mac[1];
-  mac_address[2] = mac[2];
-  mac_address[3] = mac[3];
-  mac_address[4] = mac[4];
-  mac_address[5] = mac[5];
+  stm32_eth_set_macaddr(mac_address);
 }
 
-uint8_t *EthernetClass::MACAddress(void)
+void EthernetClass::MACAddress(uint8_t *mac_address)
 {
-  return mac_address;
+  stm32_eth_get_macaddr(mac_address);
 }
 
 IPAddress EthernetClass::localIP()

--- a/src/STM32Ethernet.h
+++ b/src/STM32Ethernet.h
@@ -17,7 +17,6 @@ class EthernetClass {
   private:
     IPAddress _dnsServerAddress;
     DhcpClass *_dhcp;
-    uint8_t mac_address[6];
 
   public:
     // Initialise the Ethernet with the internal provided MAC address and gain the rest of the
@@ -42,13 +41,13 @@ class EthernetClass {
     int maintain();
     void schedule(void);
 
-    void MACAddress(uint8_t *mac);
-    uint8_t *MACAddress(void);
+    void MACAddress(uint8_t *mac_address);
     IPAddress localIP();
     IPAddress subnetMask();
     IPAddress gatewayIP();
     IPAddress dnsServerIP();
 
+    void setMACAddress(const uint8_t *mac_address);
     void setDnsServerIP(const IPAddress dns_server);
 
     friend class EthernetClient;

--- a/src/STM32Ethernet.h
+++ b/src/STM32Ethernet.h
@@ -18,7 +18,6 @@ class EthernetClass {
     IPAddress _dnsServerAddress;
     DhcpClass *_dhcp;
     uint8_t mac_address[6];
-    uint8_t   *MACAddressDefault(void);
 
   public:
     // Initialise the Ethernet with the internal provided MAC address and gain the rest of the

--- a/src/utility/ethernetif.cpp
+++ b/src/utility/ethernetif.cpp
@@ -627,8 +627,20 @@ __weak void ethernetif_notify_conn_changed(struct netif *netif)
   */
 void ethernetif_set_mac_addr(const uint8_t *mac)
 {
-  if (mac != NULL) {
+  if ((mac != NULL) && !(ethernetif_is_init())) {
     memcpy(macaddress, mac, 6);
+  }
+}
+
+/**
+  * @brief  This function get the current MAC address.
+  * @param  mac: mac address
+  * @retval None
+  */
+void ethernetif_get_mac_addr(uint8_t *mac)
+{
+  if (mac != NULL) {
+    memcpy(mac, macaddress, 6);
   }
 }
 

--- a/src/utility/ethernetif.cpp
+++ b/src/utility/ethernetif.cpp
@@ -96,6 +96,25 @@ __ALIGN_BEGIN uint8_t Tx_Buff[ETH_TXBUFNB][ETH_TX_BUF_SIZE] __ALIGN_END; /* Ethe
 
 static ETH_HandleTypeDef EthHandle;
 
+/* If default MAC fields is not defined use default values based on UID */
+#if !defined(MAC_ADDR0)
+#define MAC_ADDR0   0x00
+#endif
+#if !defined(MAC_ADDR1)
+#define MAC_ADDR1   0x80
+#endif
+#if !defined(MAC_ADDR2)
+#define MAC_ADDR2   0xE1
+#endif
+#if !defined(MAC_ADDR3)
+#define MAC_ADDR3   ((uint8_t)(((*(uint32_t *)UID_BASE) & 0x00FF0000) >> 16))
+#endif
+#if !defined(MAC_ADDR4)
+#define MAC_ADDR4   ((uint8_t)(((*(uint32_t *)UID_BASE) & 0x0000FF00) >> 8))
+#endif
+#if !defined(MAC_ADDR5)
+#define MAC_ADDR5   ((uint8_t)((*(uint32_t *)UID_BASE) & 0x000000FF))
+#endif
 static uint8_t macaddress[6] = { MAC_ADDR0, MAC_ADDR1, MAC_ADDR2, MAC_ADDR3, MAC_ADDR4, MAC_ADDR5 };
 
 #if LWIP_IGMP

--- a/src/utility/ethernetif.h
+++ b/src/utility/ethernetif.h
@@ -61,6 +61,7 @@ void ethernetif_update_config(struct netif *netif);
 void ethernetif_notify_conn_changed(struct netif *netif);
 
 void ethernetif_set_mac_addr(const uint8_t *mac);
+void ethernetif_get_mac_addr(uint8_t *mac);
 
 #if LWIP_IGMP
 err_t igmp_mac_filter(struct netif *netif, const ip4_addr_t *ip4_addr, netif_mac_filter_action action);

--- a/src/utility/stm32_eth.cpp
+++ b/src/utility/stm32_eth.cpp
@@ -269,6 +269,25 @@ uint8_t stm32_eth_is_init(void)
 }
 
 /**
+  * @brief Set Ethernet MAC address
+  * @param  mac: mac address
+  * @retval None
+  */
+void stm32_eth_set_macaddr(const uint8_t *mac)
+{
+  ethernetif_set_mac_addr(mac);
+}
+/**
+  * @brief Return Ethernet MAC address
+  * @param  mac: mac address
+  * @retval None
+  */
+void stm32_eth_get_macaddr(uint8_t *mac)
+{
+  return ethernetif_get_mac_addr(mac);
+}
+
+/**
   * @brief Return Ethernet link status
   * @param  None
   * @retval 1 for link up, 0 for link down

--- a/src/utility/stm32_eth.cpp
+++ b/src/utility/stm32_eth.cpp
@@ -117,7 +117,7 @@ static void TIM_scheduler_Config(void);
 #endif
 
 /**
-* @brief  Configurates the network interface
+* @brief  Configure the network interface
 * @param  None
 * @retval None
 */

--- a/src/utility/stm32_eth.h
+++ b/src/utility/stm32_eth.h
@@ -119,6 +119,8 @@ struct tcp_struct {
 /* Exported functions ------------------------------------------------------- */
 void stm32_eth_init(const uint8_t *mac, const uint8_t *ip, const uint8_t *gw, const uint8_t *netmask);
 uint8_t stm32_eth_is_init(void);
+void stm32_eth_get_macaddr(uint8_t *mac);
+void stm32_eth_set_macaddr(const uint8_t *mac);
 uint8_t stm32_eth_link_up(void);
 void stm32_eth_scheduler(void);
 


### PR DESCRIPTION
References:
https://www.arduino.cc/reference/en/libraries/ethernet/ethernet.macaddress/ https://www.arduino.cc/reference/en/libraries/ethernet/ethernet.setmacaddress/

> [!Important]
> Pay attention that `setMACAddress()` have to be called before `Begin()`.
> Else new MAC will be ignored.

This PR also fixes with the default MAC address usage. It is used only if one or more `MAC_ADDRx` defined.
The MAC address is also correct at all level.

Fixes #81

## Test sketch
```C++
#include <LwIP.h>
#include <STM32Ethernet.h>

byte mac[] = { 0xDE, 0xAD, 0xBE, 0xEF, 0xFE, 0xED };
IPAddress ip(192, 168, 1, 69);

void printMacAddress(byte* macBuffer) {
  Serial.print("The MAC address is: ");
  for (byte octet = 0; octet < 6; octet++) {
    Serial.printf("%02X", macBuffer[octet]);
    if (octet < 5) {
      Serial.print('-');
    } else {
      Serial.println();
    }
  }
}

void setup() {
  Serial.begin(9600);
  while (!Serial) {};
  byte macBuffer[6];  // create a buffer to hold the MAC address
  byte newMac[] = { 0x00, 0xAA, 0xBB, 0xCC, 0xDE, 0x02 };

  Ethernet.MACAddress(macBuffer);  // fill the buffer
  printMacAddress(macBuffer);      // print default MAC address
  // Selectdesired config for the test
  // Ethernet.setMACAddress(newMac);  // change the MAC address
  // Ethernet.begin(mac, ip);
  // Ethernet.begin(ip);
  Ethernet.MACAddress(macBuffer);  // fill the buffer
  printMacAddress(macBuffer);
  Ethernet.setMACAddress(newMac);  // change the MAC address
  Ethernet.MACAddress(macBuffer);  // fill the buffer
  printMacAddress(macBuffer);
}

void loop() {
}
```