### PR TITLE
Update EthernetClient.cpp

### DIFF
--- a/src/EthernetClient.cpp
+++ b/src/EthernetClient.cpp
@@ -195,7 +195,7 @@ void EthernetClient::stop()
     tcp_connection_close(_tcp_client->pcb, _tcp_client);
   }
   mem_free(_tcp_client);
-  _tcp_client=NULL;
+  _tcp_client = NULL;
 }
 
 uint8_t EthernetClient::connected()

--- a/src/EthernetClient.cpp
+++ b/src/EthernetClient.cpp
@@ -195,6 +195,7 @@ void EthernetClient::stop()
     tcp_connection_close(_tcp_client->pcb, _tcp_client);
   }
   mem_free(_tcp_client);
+  _tcp_client=NULL;
 }
 
 uint8_t EthernetClient::connected()


### PR DESCRIPTION
void EthernetClient::stop()
{
if (_tcp_client == NULL) {
return;
}

// close tcp connection if not closed yet
if (status() != TCP_CLOSING) {
tcp_connection_close(_tcp_client->pcb, _tcp_client);
}
mem_free(_tcp_client);
}

In this function, memefree (_tcp_cient);, After release, the _tcp_cient was not set to NULL, which caused an exception when TCPClient was reconnected. After adding it, it worked normally. 